### PR TITLE
Add missing paramenter in overseerr-api.yml

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -7018,6 +7018,12 @@ paths:
       description: Updates an Override Rule from the request body.
       tags:
         - overriderule
+      parameters:
+        - in: path
+          name: ruleId
+          required: true
+          schema:
+            type: number
       responses:
         '200':
           description: 'Values were successfully updated'


### PR DESCRIPTION
#### Description

While building an API client using openapi-generator-cli, I encountered an issue in overseerr-api.yml. The PUT /overrideRule/{ruleId} operation was missing a parameter definition, which I have now added.

I am not sure how Swagger UI is built or if it needs to be updated as well. Please advise if further changes are required.

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

I did not perform a build, as I believe it is unnecessary for this small fix. If building is required, please let me know.
